### PR TITLE
fixing compilation: multiple `reduce` found

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -202,7 +202,7 @@ where
 
 #[inline]
 pub fn reduce<'r, T: 'r>(f: impl FnMut(T, T) -> T, v: Vec<T>) -> Option<T> {
-    v.into_iter().reduce(f)
+    Reduce::reduce(v.into_iter(), f)
 }
 
 #[test]


### PR DESCRIPTION
Hey, thank you for fpRust!

I was trying to use it for a java like blocking array queue, and it seems exactly what i need!

but it fails to compile on recent rusts, this pr tries to fix it, please consider merging it!

```
   --> /Users/vladimir/.cargo/registry/src/github.com-1ecc6299db9ec823/fp_rust-0.1.39/src/fp.rs:205:19
    |
205 |     v.into_iter().reduce(f)
    |                   ^^^^^^ multiple `reduce` found
```

Thanks again!